### PR TITLE
fix: loading failure when configuration is not passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can add `ScalarPlug` as a plug to your project passing the configuration opt
 ### Compile-time configuration
 
 ```elixir
-plug ScalarPlug, path: "/api/docs", spec_path: "/api/spec", title: "API Documentation"
+plug ScalarPlug, path: "/api/docs", spec_href: "/api/spec", title: "API Documentation"
 ```
 
 ### MFA runtime configuration
@@ -48,7 +48,7 @@ plug ScalarPlug, {ConfigurationModule, :scalar_config}
 ### Function runtime configuration
 
 ```elixir
-plug ScalarPlug, fn -> [path: "/api/docs", spec_path: "/api/spec", title: "API Documentation"] end
+plug ScalarPlug, fn -> [path: "/api/docs", spec_href: "/api/spec", title: "API Documentation"] end
 ```
 
 <!-- tabs-close -->

--- a/lib/scalar_plug.ex
+++ b/lib/scalar_plug.ex
@@ -51,7 +51,7 @@ defmodule ScalarPlug do
     url = Keyword.get(opts, :url)
     image_url = Keyword.get(opts, :image_url)
     x_handle = Keyword.get(opts, :x_handle)
-    configuration = Keyword.get(opts, :configuration)
+    configuration = Keyword.get(opts, :configuration, %{})
     additional_head_elements = Keyword.get(opts, :additional_head_elements, [])
     additional_body_elements = Keyword.get(opts, :additional_body_elements, [])
 


### PR DESCRIPTION
If the configuration is absent, the plug sets the `data-configuration` attribute of `<script>` to `null` causing the initialization of Scalar to fail. This PR fixes it.